### PR TITLE
Make sed command work on OS X

### DIFF
--- a/install
+++ b/install
@@ -39,7 +39,7 @@ function copy {
     read -p "Do you want to copy ${DIR}/files/$1 to ~/.$1? [y/N] "
     if [[ $REPLY =~ ^[Yy]$ ]]; then
         cp ${DIR}/templates/$1 ~/.$1
-        sed -i "s/{{dotfiles}}/$(echo $DIR | sed -e 's/[\/&]/\\&/g')/g" ~/.$1
+        sed -i -e "s/{{dotfiles}}/$(echo $DIR | sed -e 's/[\/&]/\\&/g')/g" ~/.$1
     fi
 }
 


### PR DESCRIPTION
The sed command on OS X expects an extension after the -i flag. This can
be solved by explicitly using the -e flag for the expression.
